### PR TITLE
Create flake.nix for DevShell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "id": "systems",
+        "type": "indirect"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,9 @@
 	{
 		devShells = forEachSystem (pkgs: {
 			default = pkgs.mkShell {
-				packages = [
-					pkgs.win2xcur
+				packages = with pkgs; [
+					win2xcur
+					jq
 				];
 			};
 		});

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
 				packages = with pkgs; [
 					win2xcur
 					jq
+					zenity
 				];
 			};
 		});

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+	description = "Convert Windows Cursors into Xcursors via win2xcur";
+
+	inputs = {
+		nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+	};
+	outputs = { self, nixpkgs, systems }:
+	let
+		supportedSystems = nixpkgs.lib.genAttrs (import systems);
+		forEachSystem = function: supportedSystems (system: function nixpkgs.legacyPackages.${system});
+	in
+	{
+		devShells = forEachSystem (pkgs: {
+			default = pkgs.mkShell {
+				packages = [
+					pkgs.win2xcur
+				];
+			};
+		});
+	};
+}


### PR DESCRIPTION
Hello!
This PR adds a flake.nix and flake.lock. These files allow people using the nix package manager or NixOS to create a development shell which temporarily installs win2xcur.

This allows users to not clutter their systems by installing packages which would otherwise not be used.