### PR TITLE
Replace /home references and Fix bash

### DIFF
--- a/convert
+++ b/convert
@@ -1,11 +1,13 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname --  "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # test-cursor directory
-mkdir -p $HOME/win2xcur-script/test-cursor/cursors
-touch $HOME/win2xcur-script/test-cursor/index.theme
+mkdir -p $SCRIPT_DIR/test-cursor/cursors
+touch $SCRIPT_DIR/test-cursor/index.theme
 
 # Create the .converting directory
-base_dir=$HOME/win2xcur-script/.converting
+base_dir=$SCRIPT_DIR/.converting
 dirs=(
   Alternate Busy Cross Default Dgn1
   Dgn2 Hand Help Horizontal Link
@@ -17,7 +19,7 @@ for name in "${dirs[@]}"; do
 done
 
 # Create file for inside test-cursor
-cat <<EOF >> $HOME/win2xcur-script/test-cursor/index.theme
+cat <<EOF >> $SCRIPT_DIR/test-cursor/index.theme
 [Icon Theme]
 Name=test-cursor
 Comment=this is for testing
@@ -26,7 +28,7 @@ EOF
 # Convert the cursor into xcursor
 #!/bin/bash
 
-BASE_DIR="$HOME/win2xcur-script"
+BASE_DIR="$SCRIPT_DIR"
 INPUT_DIR="$BASE_DIR/input"
 CONVERTING_DIR="$BASE_DIR/.converting"
 PROCESS_DIR="$BASE_DIR/.process"
@@ -84,8 +86,8 @@ done
 
 
 # Copy into the test-cursor file
-src_base=$HOME/win2xcur-script/.process
-dest_base=$HOME/win2xcur-script/test-cursor/cursors
+src_base=$SCRIPT_DIR/.process
+dest_base=$SCRIPT_DIR/test-cursor/cursors
 
 declare -A mappings=(
   [Alternate]="bottom_left_corner bottom_right_corner bottom_side down-arrow left-arrow left_side right-arrow right_side top_left_corner top_right_corner top_side up_arrow"
@@ -113,7 +115,7 @@ for category in "${!mappings[@]}"; do
 done
 
 # Remove file
-rm $HOME/win2xcur-script/.process/*
+rm $SCRIPT_DIR/.process/*
 
 input_dirs=(
   Alternate Busy Cross Default Dgn1 Dgn2 Hand Help
@@ -121,8 +123,8 @@ input_dirs=(
 )
 
 for dir in "${input_dirs[@]}"; do
-  rm -f $HOME/win2xcur-script/input/$dir/*
+  rm -f $SCRIPT_DIR/input/$dir/*
 done
 
-rm -rf $HOME/win2xcur-script/.converting/* $HOME/win2xcur-script/.process/*
-rm $HOME/win2xcur-script/autosort/*
+rm -rf $SCRIPT_DIR/.converting/* $SCRIPT_DIR/.process/*
+rm $SCRIPT_DIR/autosort/*

--- a/convert
+++ b/convert
@@ -3,8 +3,8 @@
 SCRIPT_DIR=$( cd -- "$( dirname --  "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # test-cursor directory
-mkdir -p $SCRIPT_DIR/test-cursor/cursors
-touch $SCRIPT_DIR/test-cursor/index.theme
+mkdir -p $SCRIPT_DIR/output/test-cursor/cursors
+touch $SCRIPT_DIR/output/test-cursor/index.theme
 
 # Create the .converting directory
 base_dir=$SCRIPT_DIR/.converting
@@ -19,7 +19,7 @@ for name in "${dirs[@]}"; do
 done
 
 # Create file for inside test-cursor
-cat <<EOF >> $SCRIPT_DIR/test-cursor/index.theme
+cat <<EOF >> $SCRIPT_DIR/output/test-cursor/index.theme
 [Icon Theme]
 Name=test-cursor
 Comment=this is for testing
@@ -87,7 +87,7 @@ done
 
 # Copy into the test-cursor file
 src_base=$SCRIPT_DIR/.process
-dest_base=$SCRIPT_DIR/test-cursor/cursors
+dest_base=$SCRIPT_DIR/output/test-cursor/cursors
 
 declare -A mappings=(
   [Alternate]="bottom_left_corner bottom_right_corner bottom_side down-arrow left-arrow left_side right-arrow right_side top_left_corner top_right_corner top_side up_arrow"

--- a/create-directory-first
+++ b/create-directory-first
@@ -20,14 +20,5 @@ done
 # Create important input directory
 mkdir $SCRIPT_DIR/autosort
 
-# Give permission to each script
-chmod_bsh=$SCRIPT_DIR
-scrp=(
-	convert detail sorting start
-)
-for srp in "${scrp[@]}"; do
-	chmod +x "$chmod_bsh/${srp}"
-done
-
 # Remove this file once done
 # rm $SCRIPT_DIR/create-directory-first

--- a/create-directory-first
+++ b/create-directory-first
@@ -1,11 +1,13 @@
-#! /bin/bash
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname --  "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Create important directory
-mkdir  $HOME/win2xcur-script/.converting
-mkdir  $HOME/win2xcur-script/.process
-mkdir  $HOME/win2xcur-script/input
+mkdir  $SCRIPT_DIR/.converting
+mkdir  $SCRIPT_DIR/.process
+mkdir  $SCRIPT_DIR/input
 
-base_cur=$HOME/win2xcur-script/input
+base_cur=$SCRIPT_DIR/input
 indir=(
   Alternate Busy Cross Default Dgn1
   Dgn2 Hand Help Horizontal Link
@@ -16,10 +18,10 @@ for fil in "${indir[@]}"; do
 done
 
 # Create important input directory
-mkdir $HOME/win2xcur-script/autosort
+mkdir $SCRIPT_DIR/autosort
 
 # Give permission to each script
-chmod_bsh=$HOME/win2xcur-script
+chmod_bsh=$SCRIPT_DIR
 scrp=(
 	convert detail sorting start
 )
@@ -28,4 +30,4 @@ for srp in "${scrp[@]}"; do
 done
 
 # Remove this file once done
-rm $HOME/win2xcur-script/create-directory-first
+# rm $SCRIPT_DIR/create-directory-first

--- a/detail
+++ b/detail
@@ -1,7 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname --  "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Initial directory
-original_dir="$HOME/win2xcur-script/test-cursor"
+original_dir="$SCRIPT_DIR/test-cursor"
 theme_file="$original_dir/index.theme"
 
 # Function to update index.theme with new values
@@ -29,7 +31,7 @@ rename_directory() {
     local name="$1"
     # Replace spaces with dashes
     safe_name="${name// /-}"
-    new_dir="$HOME/win2xcur-script/$safe_name"
+    new_dir="$SCRIPT_DIR/$safe_name"
 
     if [ "$original_dir" != "$new_dir" ]; then
         mv "$original_dir" "$new_dir"

--- a/detail
+++ b/detail
@@ -3,7 +3,7 @@
 SCRIPT_DIR=$( cd -- "$( dirname --  "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Initial directory
-original_dir="$SCRIPT_DIR/test-cursor"
+original_dir="$SCRIPT_DIR/output/test-cursor"
 theme_file="$original_dir/index.theme"
 
 # Function to update index.theme with new values
@@ -31,7 +31,7 @@ rename_directory() {
     local name="$1"
     # Replace spaces with dashes
     safe_name="${name// /-}"
-    new_dir="$SCRIPT_DIR/$safe_name"
+    new_dir="$SCRIPT_DIR/output/$safe_name"
 
     if [ "$original_dir" != "$new_dir" ]; then
         mv "$original_dir" "$new_dir"

--- a/sorting
+++ b/sorting
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname --  "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Source and destination directories
-SOURCE_DIR="$HOME/win2xcur-script/autosort"
-DEST_BASE_DIR="$HOME/win2xcur-script/input"
+SOURCE_DIR="$SCRIPT_DIR/autosort"
+DEST_BASE_DIR="$SCRIPT_DIR/input"
 
 # Use jq to safely encode the directory names into a JSON array
 DIRS_JSON=$(find "$DEST_BASE_DIR" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | jq -R . | jq -s .)

--- a/start
+++ b/start
@@ -1,7 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname --  "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # Set paths
-project_dir="$HOME/win2xcur-script"
+project_dir="$SCRIPT_DIR"
 log_dir="$project_dir/.logs"
 timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
 log_file="$log_dir/run_$timestamp.log"


### PR DESCRIPTION
Hello!

This PR replaces all references of "$HOME/win2xcur-script" with references to the scripts own directory. This mitigates all potential errors caused by a different installation location and makes it more flexible.

In addition, replace bash shebang with a more universal one.